### PR TITLE
Update install_fluka.sh

### DIFF
--- a/scripts/install_fluka.sh
+++ b/scripts/install_fluka.sh
@@ -200,7 +200,7 @@ if [ ! -e ~/.fluka/fluka.version ]; then
         echo "### - Downloading the data file."
         cd /usr/local/fluka
         fluka_package_data=fluka$fluka_current_short-data.tar.gz
-        wget_return=$(wget --user=$fuid --ask-password  https://www.fluka.org/packages/${fluka_package_data})
+        wget_return=$(sudo wget --user=$fuid --ask-password  https://www.fluka.org/packages/${fluka_package_data})
         echo "### - Extracting data file to proper location."
         sudo tar -xvzf ${fluka_package_data}
         echo "### - Done extracting data file."

--- a/scripts/install_fluka.sh
+++ b/scripts/install_fluka.sh
@@ -204,6 +204,9 @@ if [ ! -e ~/.fluka/fluka.version ]; then
         echo "### - Extracting data file to proper location."
         sudo tar -xvzf ${fluka_package_data}
         echo "### - Done extracting data file."
+        sudo chown -R root.root *
+        sudo chmod -R a+rX *
+        echo "### - Permissions of data-files arranged."
     else
         # Exit with error
         echo "### - FLUKA compilation failed"

--- a/scripts/install_fluka.sh
+++ b/scripts/install_fluka.sh
@@ -196,6 +196,14 @@ if [ ! -e ~/.fluka/fluka.version ]; then
 
         touch ~/.fluka/fluka.version
         echo ${fluka_actual} > ~/.fluka/fluka.version
+        
+        echo "### - Downloading the data file."
+        cd /usr/local/fluka
+        fluka_package_data=fluka$fluka_current_short-data.tar.gz
+        wget_return=$(wget --user=$fuid --ask-password  https://www.fluka.org/packages/${fluka_package_data})
+        echo "### - Extracting data file to proper location."
+        sudo tar -xvzf ${fluka_package_data}
+        echo "### - Done extracting data file."
     else
         # Exit with error
         echo "### - FLUKA compilation failed"

--- a/scripts/install_fluka.sh
+++ b/scripts/install_fluka.sh
@@ -93,8 +93,8 @@ if [ ! -e ~/.fluka/fluka.version ]; then
         fluka_current_short=$(echo  $fluka_current | awk -F"." '{print $1 "." $2}')
 
         # Create FLUKA package filename
-        fluka_package_short=fluka$fluka_current_short-linux-gfor64bit-8.3-AA.tar.gz
-        fluka_package=fluka$fluka_current-linux-gfor64bit-8.3-AA.tar.gz
+        fluka_package_short=fluka$fluka_current_short-linux-gfor64bit-8.4-AA.tar.gz
+        fluka_package=fluka$fluka_current-linux-gfor64bit-8.4-AA.tar.gz
     fi
 
     # Check if FLUKA package with short is already downloaded


### PR DESCRIPTION
Fluka switched to gfortran 8.4. The script looks for a file that is named as if it was still called 8.3. wget gives a 404 and the installer fails. This should fix that until the gfortran version changes again.